### PR TITLE
Use \cs_new:Npn instead of \cs_new:Nn in function definition (fixes #10) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 latex-pkgloader
 ===============
 
-LaTeX Package : latex-pkgloader 0.5.0
+LaTeX Package : latex-pkgloader 0.5.1
 
-Last Modified : 2014-11-30
+Last Modified : 2017-09-20
 
 Author        : Michiel Helvensteijn  (www.mhelvens.net)
 

--- a/archive
+++ b/archive
@@ -18,7 +18,7 @@ FILES="$DOC.sty          \
        $DOC-recommended.sty         \
        README.md"
 
-VERSION=0.5.0
+VERSION=0.5.1
 
 ##################################################
 #

--- a/pkgloader.sty
+++ b/pkgloader.sty
@@ -844,7 +844,7 @@
 %  filenames from their four character extension:
 %  
 %    \begin{macrocode}
-\cs_new:Nn \__pkgloader_strip_extension:f {
+\cs_new:Npn \__pkgloader_strip_extension:f #1 {
   \tl_reverse:f{
     \tl_tail:f{\tl_tail:f{\tl_tail:f{\tl_tail:f{
       \tl_reverse:n{#1}

--- a/pkgloader.sty
+++ b/pkgloader.sty
@@ -48,7 +48,7 @@
 %    \begin{macrocode}
 \NeedsTeXFormat{LaTeX2e}
 \RequirePackage{expl3}
-\ProvidesExplPackage{pkgloader}{2014/11/30}{0.5.0}
+\ProvidesExplPackage{pkgloader}{2017/09/20}{0.5.1}
   {managing the options and loading order of LaTeX packages}
 %    \end{macrocode}
 %

--- a/pkgloader.tex
+++ b/pkgloader.tex
@@ -48,6 +48,9 @@
 \changes{0.5.0}{2014/11/30}
   {integrates a number of new package loading rules contributed by the community}
 
+\changes{0.5.1}{2017/09/20}
+  {fixed the package to work aafter \cs_new:Nn was changed to only allow 'N' and 'n' in function signatures (2016/08/20)}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{document}                                                               %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
This is my fix for issue  #10 that I submitted a few minutes ago.
I took the liberty to bump the version numbers too.
I tested this on texlive as installed in my debian buster laptop.