### PR TITLE
Set fixltx2e optional

### DIFF
--- a/pkgloader-recommended.sty
+++ b/pkgloader-recommended.sty
@@ -24,7 +24,7 @@
 %  <http://www.macfreek.nl/memory/LaTeX_package_conflicts>:
 %
 %    \begin{macrocode}
-\Load {fixltx2e}  early              always
+\Load {fixltx2e}  early              if loaded
 \Load {fancyhdr}  before {hyperref}  if loaded
 \Load {fncychap}  before {hyperref}  if loaded
 \Load {float}     before {hyperref}  if loaded


### PR DESCRIPTION
Quoting the package README from https://ctan.org/pkg/fixltx2e

> This pack­age does noth­ing other than is­sue a warn­ing in cur­rent LaTeX Re­leases.

So, it should not be loaded